### PR TITLE
Fix ci coverage lcov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -248,6 +248,17 @@ ModelManifest.xml
 coverage.info
 *.gcda
 *.gcno
+test/*.png
+test/*.html
+test/*.css
+test/bin/
+test/home/
+test/include/
+test/test
+test/5/
+
+# Visual Studio Code
+.vscode/
 
 # Other
 *.dump

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ compiler:
   - gcc
 cache:
   apt: true
+sudo: required
 addons:
   apt:
     sources:
@@ -27,7 +28,7 @@ install:
         pwd
         git clone https://github.com/linux-test-project/lcov.git ./lcov
         cd lcov
-        make install
+        sudo make install
         cd ..
         pwd
         gem install lcoveralls; 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
       - llvm-toolchain-precise-3.8
       - llvm-toolchain-precise
     packages:
-      - lcov
+      #- lcov
       - rubygems
       - clang-3.8
       - g++-5
@@ -23,7 +23,15 @@ install:
   - |
     if [ "${USE_COVERALLS}" = '1' ]; then
       if [ "${USE_COVERAGE}" = 'gcov' ]; then easy_install cpp-coveralls; fi
-      if [ "${USE_COVERAGE}" = 'lcov' ]; then gem install lcoveralls; fi
+      if [ "${USE_COVERAGE}" = 'lcov' ]; then 
+        pwd
+        git clone https://github.com/linux-test-project/lcov.git ./lcov
+        cd lcov
+        make install
+        cd ..
+        pwd
+        gem install lcoveralls; 
+      fi
     fi
 language: cpp
 script:

--- a/test/Makefile
+++ b/test/Makefile
@@ -55,7 +55,7 @@ coverage:
 	$(CCOV) -v
 ifeq ($(USE_COVERAGE),lcov)
 	lcov --version
-	lcov -c -d . --gcov-tool "$(shell which $(CCOV))" -o coverage.info && lcov -r coverage.info *gcc* -o coverage.info && lcov -r coverage.info *iutest* -o coverage.info && lcov -r coverage.info *mingw* -o coverage.info;
+	lcov -c -d . --gcov-tool "$(shell which $(CCOV))" -o coverage.info && lcov -r coverage.info *gcc* -o coverage.info && lcov -r coverage.info *iutest* -o coverage.info && lcov -r coverage.info */usr/include/* -o coverage.info && lcov -r coverage.info *mingw* -o coverage.info;
 endif
 ifeq ($(USE_COVERAGE),gcov)
 ifeq ($(findstring relative-only, $(shell $(CCOV) --help)), relative-only)

--- a/test/Makefile
+++ b/test/Makefile
@@ -68,7 +68,7 @@ endif
 # send-coveralls
 .PHONY: send-coveralls
 send-coveralls: coverage
-pwd
+pwd;
 ifeq ($(USE_COVERAGE),lcov)
 	cd ../; lcoveralls --retry-count 3 ./test/coverage.info
 endif

--- a/test/Makefile
+++ b/test/Makefile
@@ -68,10 +68,9 @@ endif
 # send-coveralls
 .PHONY: send-coveralls
 send-coveralls: coverage
+pwd
 ifeq ($(USE_COVERAGE),lcov)
-	pwd
-	cd ..
-	lcoveralls --retry-count 3 ./test/coverage.info
+	cd ../; lcoveralls --retry-count 3 ./test/coverage.info
 endif
 ifeq ($(USE_COVERAGE),gcov)
 	coveralls -n -r ./ -b ./ $(COVARALLS_EXCLUDE_PATTERN) $(COVARALLS_EXCLUDE)

--- a/test/Makefile
+++ b/test/Makefile
@@ -69,7 +69,9 @@ endif
 .PHONY: send-coveralls
 send-coveralls: coverage
 ifeq ($(USE_COVERAGE),lcov)
-	lcoveralls --retry-count 3 ./coverage.info
+	pwd
+	cd ..
+	lcoveralls --retry-count 3 ./test/coverage.info
 endif
 ifeq ($(USE_COVERAGE),gcov)
 	coveralls -n -r ./ -b ./ $(COVARALLS_EXCLUDE_PATTERN) $(COVARALLS_EXCLUDE)

--- a/test/Makefile
+++ b/test/Makefile
@@ -68,7 +68,7 @@ endif
 # send-coveralls
 .PHONY: send-coveralls
 send-coveralls: coverage
-pwd;
+	pwd
 ifeq ($(USE_COVERAGE),lcov)
 	cd ../; lcoveralls --retry-count 3 ./test/coverage.info
 endif


### PR DESCRIPTION
- `lcov`を`apt-get`からinstallするのをやめてgitで落とすように
- `lcoveralls`の呼び出し方を修正
